### PR TITLE
DM-30249: Use teal for badge-notification:new-topic

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -24,3 +24,8 @@
 .read-state {
   color: var(--tertiary);
 }
+
+// Color of unread icon in post listing on homepage
+.badge-notification.new-topic::before {
+  background: var(--tertiary);
+}


### PR DESCRIPTION
Again, for more brand consistency.