### PR TITLE
DM-50332: Reset header height changes

### DIFF
--- a/desktop/desktop.scss
+++ b/desktop/desktop.scss
@@ -1,9 +1,9 @@
 .d-header {
-  height: 240px;
+  height: 120px;
 }
 
 .d-header #site-logo {
-  height: 220px;
+  height: 90px;
 }
 
 .extra-info-wrapper {


### PR DESCRIPTION
We're moving the horizontal triad logo to a new div above the main
header and switching the logo to just "Community forum" wordmark, so we
don't need the extra height.